### PR TITLE
Feature/brooklyn catalogue yaml

### DIFF
--- a/camp/camp-base/src/main/java/io/brooklyn/camp/spi/pdp/DeploymentPlan.java
+++ b/camp/camp-base/src/main/java/io/brooklyn/camp/spi/pdp/DeploymentPlan.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import brooklyn.util.collections.MutableMap;
+import brooklyn.util.guava.Maybe;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -69,22 +70,46 @@ public class DeploymentPlan {
     public String getName() {
         return name;
     }
+
     public String getDescription() {
         return description;
     }
+
     public String getOrigin() {
         return origin;
     }
+
     public List<Artifact> getArtifacts() {
         return ImmutableList.copyOf(artifacts);
     }
+
     public List<Service> getServices() {
         return ImmutableList.copyOf(services);
     }
+
     public Map<String, Object> getCustomAttributes() {
         return ImmutableMap.copyOf(customAttributes);
     }
-    
+
+    /**
+     * Returns a present {@link Maybe} of the custom attribute with the given name if the attribute is
+     * non-null and is an instance of the given type. Otherwise returns absent.
+     * <p/>
+     * Does not remove the attribute from the custom attribute map.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Maybe<T> getCustomAttribute(String attributeName, Class<T> type) {
+        Object attribute = customAttributes.get(attributeName);
+        if (attribute == null) {
+            return Maybe.absent("Custom attributes does not contain " + attributeName);
+        } else if (!type.isAssignableFrom(attribute.getClass())) {
+            return Maybe.absent("Custom attribute " + attributeName + " is not of expected type: " +
+                    "expected=" + type.getName() + " actual=" + attribute.getClass().getName());
+        } else {
+            return Maybe.of((T) attribute);
+        }
+    }
+
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);

--- a/core/src/main/java/brooklyn/catalog/internal/CatalogLibrariesDto.java
+++ b/core/src/main/java/brooklyn/catalog/internal/CatalogLibrariesDto.java
@@ -2,7 +2,11 @@ package brooklyn.catalog.internal;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -11,20 +15,50 @@ import brooklyn.catalog.CatalogItem;
 
 public class CatalogLibrariesDto implements CatalogItem.CatalogItemLibraries {
 
+    private static Logger LOG = LoggerFactory.getLogger(CatalogLibrariesDto.class);
+
+    // TODO: Incorporate name and version into entries
     private List<String> bundles = new CopyOnWriteArrayList<String>();
 
     public void addBundle(String url) {
         Preconditions.checkNotNull(bundles, "Cannot add a bundle to a deserialized DTO");
-        bundles.add( Preconditions.checkNotNull(url) );
+        bundles.add(Preconditions.checkNotNull(url, "url"));
     }
 
-    /** @return An immutable copy of the bundle URLs referenced by this object */
+    /**
+     * @return An immutable copy of the bundle URLs referenced by this object
+     */
     public List<String> getBundles() {
-        if (bundles==null)  {
+        if (bundles == null) {
             // can be null on deserialization
             return Collections.emptyList();
         }
         return ImmutableList.copyOf(bundles);
     }
 
+    /**
+     * Parses an instance of CatalogLibrariesDto from the given List. Expects the list entries
+     * to be maps of string -> string. Will skip items that are not.
+     */
+    public static CatalogLibrariesDto fromList(List<?> possibleLibraries) {
+        CatalogLibrariesDto dto = new CatalogLibrariesDto();
+        for (Object object : possibleLibraries) {
+            if (object instanceof Map) {
+                Map entry = (Map) object;
+                String name = stringValOrNull(entry, "name");
+                String version = stringValOrNull(entry, "version");
+                String url = stringValOrNull(entry, "url");
+                dto.addBundle(url);
+            } else {
+                LOG.debug("Unexpected entry in libraries list not instance of map: " + object);
+            }
+        }
+
+        return dto;
+    }
+
+    private static String stringValOrNull(Map map, String key) {
+        Object val = map.get(key);
+        return val != null ? String.valueOf(val) : null;
+    }
 }

--- a/core/src/test/java/brooklyn/camp/lite/CampYamlLiteTest.java
+++ b/core/src/test/java/brooklyn/camp/lite/CampYamlLiteTest.java
@@ -8,6 +8,7 @@ import io.brooklyn.camp.test.mock.web.MockWebPlatform;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +29,7 @@ import brooklyn.util.stream.Streams;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 
 /** Tests of lightweight CAMP integration. Since the "real" integration is in brooklyn-camp project,
  * but some aspects of CAMP we want to be able to test here. */
@@ -83,16 +85,23 @@ public class CampYamlLiteTest {
         MockWebPlatform.populate(platform, TestAppAssemblyInstantiator.class);
         
         CatalogItem<?, ?> realItem = mgmt.getCatalog().addItem(Streams.readFullyString(getClass().getResourceAsStream("test-app-service-blueprint.yaml")));
-        Iterable<CatalogItem<Object, Object>> retrievedItems = mgmt.getCatalog().getCatalogItems(CatalogPredicates.registeredType(Predicates.equalTo("sample")));
+        Iterable<CatalogItem<Object, Object>> retrievedItems = mgmt.getCatalog()
+                .getCatalogItems(CatalogPredicates.registeredType(Predicates.equalTo("catalog-name")));
         
         Assert.assertEquals(Iterables.size(retrievedItems), 1, "Wrong retrieved items: "+retrievedItems);
         CatalogItem<Object, Object> retrievedItem = Iterables.getOnlyElement(retrievedItems);
         Assert.assertEquals(retrievedItem, realItem);
-        
+
+        Set<String> expectedBundles = Sets.newHashSet("http://www.example.com/bundle.jar");
+        Assert.assertEquals(retrievedItem.getLibraries().getBundles(), expectedBundles);
+        // Assert.assertEquals(retrievedItem.getVersion(), "0.9");
+
+
         EntitySpec<?> spec1 = (EntitySpec<?>) mgmt.getCatalog().createSpec(retrievedItem);
         Assert.assertNotNull(spec1);
         Assert.assertEquals(spec1.getConfig().get(TestEntity.CONF_NAME), "sample");
         
         // TODO other assertions, about children
     }
+
 }

--- a/core/src/test/resources/brooklyn/camp/lite/test-app-service-blueprint.yaml
+++ b/core/src/test/resources/brooklyn/camp/lite/test-app-service-blueprint.yaml
@@ -9,3 +9,12 @@ services:
         /: hello.war
     controller.spec:
         port: 80
+
+brooklyn.catalog:
+  name: catalog-name
+  type: io.camp.mock.MyApplication
+  version: 0.9
+  libraries:
+  - name: lib1
+    version: v1
+    url: http://www.example.com/bundle.jar

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityMatcher.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityMatcher.java
@@ -22,6 +22,7 @@ import brooklyn.util.flags.FlagUtils.FlagConfigKeyAndValueRecord;
 import brooklyn.util.text.Strings;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 public class BrooklynEntityMatcher implements PdpMatcher {
 
@@ -115,6 +116,7 @@ public class BrooklynEntityMatcher implements PdpMatcher {
         addCustomListAttributeIfNonNull(builder, attrs, "brooklyn.enrichers");
         addCustomListAttributeIfNonNull(builder, attrs, "brooklyn.initializers");
         addCustomListAttributeIfNonNull(builder, attrs, "brooklyn.children");
+        addCustomMapAttributeIfNonNull(builder, attrs, "brooklyn.catalog");
 
         if (!attrs.isEmpty()) {
             log.warn("Ignoring PDP attributes on "+deploymentPlanItem+": "+attrs);
@@ -142,6 +144,23 @@ public class BrooklynEntityMatcher implements PdpMatcher {
                 throw new IllegalArgumentException(key + " must be a list, is: " + items.getClass().getName());
             }
         }
+    }
+
+    /**
+     * Looks for the given key in the map of attributes and adds it to the given builder
+     * as a custom attribute with type Map.
+     * @throws java.lang.IllegalArgumentException if map[key] is not an instance of Map
+     */
+    private void addCustomMapAttributeIfNonNull(Builder<? extends PlatformComponentTemplate> builder, Map attrs, String key) {
+        Object items = attrs.remove(key);
+        if (items != null) {
+            if (items instanceof Map) {
+                Map<?, ?> itemMap = (Map<?, ?>) items;
+                if (!itemMap.isEmpty()) {
+                    builder.customAttribute(key, Maps.newHashMap(itemMap));
+                }
+            } else {
+                throw new IllegalArgumentException(key + " must be a map, is: " + items.getClass().getName());
             }
         }
     }

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslInterpreter.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslInterpreter.java
@@ -76,7 +76,7 @@ public class BrooklynDslInterpreter extends PlanInterpreterAdapter {
     
     @Override
     public boolean applyMapEntry(PlanInterpretationNode node, Map<Object, Object> mapIn, Map<Object, Object> mapOut,
-                            PlanInterpretationNode key, PlanInterpretationNode value) {
+            PlanInterpretationNode key, PlanInterpretationNode value) {
         if (key.getNewValue() instanceof FunctionWithArgs) {
             try {
                 currentNode.set(node);


### PR DESCRIPTION
Supports brooklyn.catalog in yaml and its usage in BasicBrooklynCatalog

Notes:
- Only bundle urls are used at the moment. Name/version need to be added to CatalogLibrariesDto.
